### PR TITLE
Force use of system ninja.

### DIFF
--- a/tools/Dockerfile.devtools
+++ b/tools/Dockerfile.devtools
@@ -25,7 +25,7 @@ MAINTAINER "Carlos O'Ryan <coryan@users.noreply.github.com>"
 #   - ninja-build is a backend for CMake that often compiles faster than
 #     CMake with GNU Make.
 #   - Install the boost libraries.
-#   -
+#
 RUN apk update && \
     apk add \
         boost-dev \
@@ -40,7 +40,8 @@ RUN apk update && \
         ninja \
         perl \
         unzip \
-        tar
+        tar \
+        zip
 
 # Use vcpkg (https://github.com/Microsoft/vcpkg.git) to compile the dependencies
 # that do not have Ubuntu packages.
@@ -54,10 +55,10 @@ WORKDIR /l/vcpkg
 # Compile vcpkg. By default vcpkg downloads CMake, Ninja, Perl and other
 # binaries, my guess is that this makes the builds more reproduceable. However,
 # in our case the pre-installed binaries work fine.
-RUN ./bootstrap-vcpkg.sh --useSystemBinaries
+RUN VCPKG_FORCE_SYSTEM_BINARIES=1 ./bootstrap-vcpkg.sh -disableMetrics 
 
 # Download and compile gRPC and its dependencies.
-RUN ./vcpkg install --triplet x64-linux grpc
+RUN VCPKG_FORCE_SYSTEM_BINARIES=1 ./vcpkg install --triplet x64-linux grpc
 
 # Create the final Docker image, copy the final vcpkg artifacts, but remove the
 # intermediate ones, this reduces the image size from ~11GiB to ~2GiB.


### PR DESCRIPTION
```
Author: Rob Shakir <rjs@rob.sh>
Date:   Mon Feb 21 18:05:42 2022 -0500

    Force vcpkg to use local binaries.
    
     * (M) tools/Dockerfile.devtools
       - Install zip which is otherwise missing.
       - Ensure that vcpkg is forced to use system binaries (replacing
         the deprecated flag).
```

This allows the contents of this repo to be used with the current `vcpkg`, and was succesfully tested to create the both the tools and the server docker image from the repo.

## Verification output

```
[18:04] c/cpp/simplegrpc   master ✔                                                                                                                                                                                         1127d ⚑  
▶ docker build --no-cache -t grpc-cpp-devtools:latest -f tools/Dockerfile.devtools tools 
[+] Building 887.8s (14/14) FINISHED                                                                                                                                                                                                  
 => [internal] load build definition from Dockerfile.devtools                                                                                                                                                                    0.0s
 => => transferring dockerfile: 46B                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/alpine:edge                                                                                                                                                                   0.8s
 => CACHED [devtools 1/2] FROM docker.io/library/alpine:edge@sha256:1a4c2018cfbab67566904e18fde9bf6a5c190605bf7da0e1d181b26746a15188                                                                                             0.0s
 => [devtools 2/2] RUN apk update &&     apk add         boost-dev         boost-static         build-base         cmake         curl         git         gcc         g++         libc-dev         ninja         perl           12.2s
 => [stage-2 1/5] WORKDIR /l/                                                                                                                                                                                                    0.0s
 => [stage-2 2/5] RUN git clone https://github.com/Microsoft/vcpkg.git                                                                                                                                                          14.2s 
 => [with_vcpkg 3/5] WORKDIR /l/vcpkg                                                                                                                                                                                            0.0s 
 => [with_vcpkg 4/5] RUN VCPKG_FORCE_SYSTEM_BINARIES=1 ./bootstrap-vcpkg.sh -disableMetrics                                                                                                                                      1.1s 
 => [with_vcpkg 5/5] RUN VCPKG_FORCE_SYSTEM_BINARIES=1 ./vcpkg install --triplet x64-linux grpc                                                                                                                                846.2s 
 => [stage-2 3/5] COPY --from=with_vcpkg /l/vcpkg/installed /l/vcpkg/installed                                                                                                                                                   1.0s 
 => [stage-2 4/5] COPY --from=with_vcpkg /l/vcpkg/vcpkg /l/vcpkg                                                                                                                                                                 0.1s 
 => [stage-2 5/5] RUN /l/vcpkg/vcpkg list                                                                                                                                                                                        0.3s 
 => exporting to image                                                                                                                                                                                                           8.4s 
 => => exporting layers                                                                                                                                                                                                          8.4s 
 => => writing image sha256:1c76f3b5797e6afc48cf31901371458a55a2d10b9c71c2cdf4b8c42231d34e91                                                                                                                                     0.0s 
 => => naming to docker.io/library/grpc-cpp-devtools:latest                                                                                                                                                                      0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

[18:22] c/cpp/simplegrpc   master ✔                                                                                                                                                                                         1127d ⚑  
▶ docker build --no-cache -t grpc-cpp-echo:latest -f examples/echo/Dockerfile.server .   
[+] Building 10.9s (14/14) FINISHED                                                                                                                                                                                                   
 => [internal] load build definition from Dockerfile.server                                                                                                                                                                      0.0s
 => => transferring dockerfile: 44B                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                0.0s
 => => transferring context: 34B                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                 1.0s
 => [internal] load metadata for docker.io/library/grpc-cpp-devtools:latest                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                0.0s
 => => transferring context: 593B                                                                                                                                                                                                0.0s
 => [build 1/6] FROM docker.io/library/grpc-cpp-devtools:latest                                                                                                                                                                  0.1s
 => CACHED [stage-1 1/2] FROM docker.io/library/alpine:latest@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300                                                                                            0.0s
 => [build 2/6] COPY . /w                                                                                                                                                                                                        0.0s
 => [build 3/6] WORKDIR /w                                                                                                                                                                                                       0.0s
 => [build 4/6] RUN cmake -H. -B.build     -GNinja     -DCMAKE_BUILD_TYPE=Release     -DCMAKE_TOOLCHAIN_FILE=/l/vcpkg/scripts/buildsystems/vcpkg.cmake     -DBoost_USE_STATIC_LIBS=ON     -DCMAKE_EXE_LINKER_FLAGS="-static"     0.8s
 => [build 5/6] RUN cmake --build .build                                                                                                                                                                                         8.3s
 => [build 6/6] RUN strip .build/examples/echo/echo_server .build/examples/echo/echo_client                                                                                                                                      0.3s 
 => [stage-1 2/2] COPY --from=build     /w/.build/examples/echo/echo_server     /w/.build/examples/echo/echo_client     /r/                                                                                                      0.1s 
 => exporting to image                                                                                                                                                                                                           0.1s 
 => => exporting layers                                                                                                                                                                                                          0.1s 
 => => writing image sha256:5199fbfb9989a24adf4d49a77578f4109271c432edd489693dd9a2e2a793ce1c                                                                                                                                     0.0s 
 => => naming to docker.io/library/grpc-cpp-echo:latest                                                                                                                                                                          0.0s 

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

[18:23] c/cpp/simplegrpc   master ✔                                                                                                                                                                                         1127d ⚑  
▶ ID=$(docker run -d -P grpc-cpp-echo:latest /r/echo_server)

[18:23] c/cpp/simplegrpc   master ✔                                                                                                                                                                                         1127d ⚑  
▶ ADDRESS=$(docker port "${ID}" 7000)

[18:23] c/cpp/simplegrpc   master ✔                                                                                                                                                                                         1127d ⚑  
▶ docker run --network=host grpc-cpp-echo:latest /r/echo_client --address "${ADDRESS}"

Response ping-0
Response ping-1
Response ping-2
Response ping-3
Response ping-4
Response ping-5
Response ping-6
Response ping-7
Response ping-8
Response ping-9
```
